### PR TITLE
fix: process_graphic_recordingのデッドコードとbare exceptを修正 (#2, #3)

### DIFF
--- a/Stream_ClaudeDiscordBot.py
+++ b/Stream_ClaudeDiscordBot.py
@@ -466,15 +466,13 @@ async def process_graphic_recording(message, prompt, attachment=None):
                     )
                     full_prompt = f"{enhanced_prompt}\n\n{file_info}{text_data}"
                     content = full_prompt
-                except:
+                except Exception as e:
+                    usage_logger.error(f"Failed to process text file {attachment.filename}: {e}")
                     await message.channel.send(f"このファイル形式は処理できません。")
                     return
-            
+
             # 共通の処理部分
-            if isinstance(content, list):
-                update_history(message.author.id, content, 'user')
-            else:
-                update_history(message.author.id, content, 'user')
+            update_history(message.author.id, content, 'user')
                 
             formatted_history = get_history(message.author.id)
             thinking_text, response_text = await generate_response(formatted_history)


### PR DESCRIPTION
## Summary
- Issue #2: `isinstance(content, list)` の両ブランチが同一処理だったデッドコードを削除
- Issue #3: bare `except:` を `except Exception as e:` に変更し、エラーを `usage_logger` に記録するよう修正

## Changes
[Stream_ClaudeDiscordBot.py](Stream_ClaudeDiscordBot.py)
- `isinstance` 分岐を削除し `update_history()` の1行に統合
- `except:` → `except Exception as e:` + `usage_logger.error(...)` に変更

## Test plan
- [x] bot が正常起動・Gateway 接続することを確認
- [ ] `!gra` コマンドでテキストファイルを添付してグラフィックレコーディングが生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)