### PR TITLE
impl: SYSTEM_PROMPTを.envからオプション設定できるようにする (#5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ GCP_REGION=global
 GCP_PROJECT_ID=your_gcp_project_id
 MAX_HISTORY=10
 MODEL=claude-sonnet-4-6
+# Optional. If empty, no system prompt is sent to Claude.
+SYSTEM_PROMPT=

--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ The bot uses Python's standard `mimetypes` module to automatically detect file t
     GCP_PROJECT_ID=your_gcp_project_id
     MAX_HISTORY=10
     MODEL=claude-sonnet-4-6
+    SYSTEM_PROMPT=
     ```
 
-    Replace the placeholders with your actual information.  `MAX_HISTORY` refers to the number of *pairs* of user/assistant messages to store.  `MODEL` is the name of the Vertex AI model to use (e.g., `claude-sonnet-4-6` or `claude-opus-4-6`).
+    Replace the placeholders with your actual information.  `MAX_HISTORY` refers to the number of *pairs* of user/assistant messages to store.  `MODEL` is the name of the Vertex AI model to use (e.g., `claude-sonnet-4-6` or `claude-opus-4-6`). `SYSTEM_PROMPT` is optional — set a string to customize the bot's persona/behavior, or leave empty to send no system prompt.
 
 
 

--- a/Stream_ClaudeDiscordBot.py
+++ b/Stream_ClaudeDiscordBot.py
@@ -46,6 +46,7 @@ MAX_HISTORY = 2 * int(os.getenv("MAX_HISTORY", "0"))
 MAX_DISCORD_LENGTH = 2000
 LLM_MODEL = os.getenv("MODEL")
 MAX_TOKEN = 64000
+SYSTEM_PROMPT = os.getenv("SYSTEM_PROMPT", "")
 
 MAX_IMAGE_SIZE_MB = 1
 
@@ -173,13 +174,17 @@ async def generate_response(message_text):
     thinking_output = ""
     response_output = ""
     
+    stream_kwargs = {
+        "model": LLM_MODEL,
+        "max_tokens": MAX_TOKEN,
+        "thinking": {"type": "adaptive"},
+        "messages": message_text,
+    }
+    if SYSTEM_PROMPT:
+        stream_kwargs["system"] = SYSTEM_PROMPT
+
     # Receive responses using the Stream API
-    async with anthropic.messages.stream(
-        model=LLM_MODEL,
-        max_tokens=MAX_TOKEN,
-        thinking={"type": "adaptive"},
-        messages=message_text,
-    ) as stream:
+    async with anthropic.messages.stream(**stream_kwargs) as stream:
         async for event in stream:
             if event.type == "content_block_start":
                 # Record block start (if needed for debugging purposes)


### PR DESCRIPTION
## Summary
- Claude API の \`system\` パラメータを \`.env\` の \`SYSTEM_PROMPT\` から設定可能に
- デフォルトは空（システムプロンプトなし）で従来挙動を維持

## Changes
- [Stream_ClaudeDiscordBot.py](Stream_ClaudeDiscordBot.py): \`SYSTEM_PROMPT\` 定数を追加、\`generate_response()\` で設定時のみ \`system\` kwarg を渡す
- [.env.example](.env.example): \`SYSTEM_PROMPT=\` を追記
- [README.md](README.md): \`SYSTEM_PROMPT\` の説明を追記

## Test plan
- [x] デフォルト（空）で bot が通常通り応答することを確認
- [x] \`SYSTEM_PROMPT\` を設定して指定ペルソナで応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)