### PR TITLE
impl: Claude Web Search (web_search_20250305) を統合 (#14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ MAX_HISTORY=10
 MODEL=claude-sonnet-4-6
 # Optional. If empty, no system prompt is sent to Claude.
 SYSTEM_PROMPT=
+# Optional. 0 disables web search. When >0, Claude may invoke up to N web searches per response ($10/1,000 searches).
+WEB_SEARCH_MAX_USES=0

--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ The bot uses Python's standard `mimetypes` module to automatically detect file t
     MAX_HISTORY=10
     MODEL=claude-sonnet-4-6
     SYSTEM_PROMPT=
+    WEB_SEARCH_MAX_USES=0
     ```
 
-    Replace the placeholders with your actual information.  `MAX_HISTORY` refers to the number of *pairs* of user/assistant messages to store.  `MODEL` is the name of the Vertex AI model to use (e.g., `claude-sonnet-4-6` or `claude-opus-4-6`). `SYSTEM_PROMPT` is optional — set a string to customize the bot's persona/behavior, or leave empty to send no system prompt.
+    Replace the placeholders with your actual information.  `MAX_HISTORY` refers to the number of *pairs* of user/assistant messages to store.  `MODEL` is the name of the Vertex AI model to use (e.g., `claude-sonnet-4-6` or `claude-opus-4-6`). `SYSTEM_PROMPT` is optional — set a string to customize the bot's persona/behavior, or leave empty to send no system prompt. `WEB_SEARCH_MAX_USES` controls Claude's built-in web search: set to 0 to disable (default), or a positive integer to allow Claude to perform up to that many web searches per response (billed at $10 per 1,000 searches by Anthropic). Source URLs are appended to responses as a Markdown list.
 
 
 

--- a/Stream_ClaudeDiscordBot.py
+++ b/Stream_ClaudeDiscordBot.py
@@ -47,6 +47,7 @@ MAX_DISCORD_LENGTH = 2000
 LLM_MODEL = os.getenv("MODEL")
 MAX_TOKEN = 64000
 SYSTEM_PROMPT = os.getenv("SYSTEM_PROMPT", "")
+WEB_SEARCH_MAX_USES = int(os.getenv("WEB_SEARCH_MAX_USES", "0"))
 
 MAX_IMAGE_SIZE_MB = 1
 
@@ -182,6 +183,12 @@ async def generate_response(message_text):
     }
     if SYSTEM_PROMPT:
         stream_kwargs["system"] = SYSTEM_PROMPT
+    if WEB_SEARCH_MAX_USES > 0:
+        stream_kwargs["tools"] = [{
+            "type": "web_search_20250305",
+            "name": "web_search",
+            "max_uses": WEB_SEARCH_MAX_USES,
+        }]
 
     # Receive responses using the Stream API
     async with anthropic.messages.stream(**stream_kwargs) as stream:
@@ -201,6 +208,22 @@ async def generate_response(message_text):
             elif event.type == "content_block_stop":
                 # Record block end (if needed for debugging purposes)
                 pass
+
+        if WEB_SEARCH_MAX_USES > 0:
+            final_message = await stream.get_final_message()
+            seen_urls = {}
+            for block in final_message.content:
+                if getattr(block, "type", None) != "text":
+                    continue
+                for c in getattr(block, "citations", None) or []:
+                    url = getattr(c, "url", None)
+                    if url and url not in seen_urls:
+                        seen_urls[url] = getattr(c, "title", None) or url
+            if seen_urls:
+                sources_md = "\n\n**📚 Sources:**\n" + "\n".join(
+                    f"- [{title}]({url})" for url, title in seen_urls.items()
+                )
+                response_output += sources_md
     
     # If using the thinking process, you can log or save it here
     # Example of logging: logging.debug(f"Thinking process: {thinking_output[:100]}...")


### PR DESCRIPTION
## Summary
- `.env` の `WEB_SEARCH_MAX_USES` (int, default `0`) でClaude組み込みのWeb検索を有効化
- `>0` のとき `tools=[{"type": "web_search_20250305", ...}]` をストリーミングリクエストに追加
- Claude が必要と判断したときのみ検索実行
- 応答末尾に `📚 Sources:` Markdown リストで引用URLを付加（URL重複排除）
- 引用MD込みのテキストを履歴保存 → 次ターンでも Claude が参照可能

## Design
- `thinking={"type": "adaptive"}` と完全併用
- アーキ変更なし（既存の `update_history` / `send_long_message` / `save_response_as_file_and_send` をそのまま利用）
- VertexAI 経由でGAサポートの `web_search_20250305` を採用（動的フィルタ `web_search_20260209` は VertexAI 非対応のため不採用）

## Test plan
- [x] `WEB_SEARCH_MAX_USES=0`（デフォルト）で通常動作にデグレ無し
- [x] `WEB_SEARCH_MAX_USES=3` で時事質問に対し Sources が付く
- [x] 検索不要な質問では Sources が付かない
- [x] `!save` 時にファイル内に Sources MD が含まれる

## Cost note
`$10 / 1,000 searches`（Anthropic 公式）。`max_uses` で per-response 上限を制御。

🤖 Generated with [Claude Code](https://claude.com/claude-code)