### PR TITLE
fix: 大画像処理の堅牢化 (DecompressionBombError + asyncio ブロック) (#16)

### DIFF
--- a/Stream_ClaudeDiscordBot.py
+++ b/Stream_ClaudeDiscordBot.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import re
 import aiohttp
@@ -12,6 +13,11 @@ import datetime
 import mimetypes
 
 import logging
+
+# Accept large scientific images (microscopy, astronomy, high-res figures).
+# Trusted-user private bot context; keep sanity via the file_data download
+# limit upstream rather than Pillow's pixel bomb check.
+Image.MAX_IMAGE_PIXELS = None
 
 # Load environment variables
 load_dotenv()
@@ -50,6 +56,8 @@ SYSTEM_PROMPT = os.getenv("SYSTEM_PROMPT", "")
 WEB_SEARCH_MAX_USES = int(os.getenv("WEB_SEARCH_MAX_USES", "0"))
 
 MAX_IMAGE_SIZE_MB = 1
+INITIAL_MAX_DIMENSION = 4096
+MIN_DIMENSION = 64
 
 # Initialize
 anthropic = AsyncAnthropicVertex(region=GCP_REGION, project_id=GCP_PROJECT_ID)
@@ -128,27 +136,41 @@ def clean_message(input_string):
 
 
 def resize_image(image_bytes, file_extension, max_size_mb=MAX_IMAGE_SIZE_MB, step=10):
-    """Resizes the image to be under the max size."""
+    """Resizes the image to be under the max size. Returns None on decode/resize failure."""
     format_map = {'.png': 'PNG', '.jpg': 'JPEG', '.jpeg': 'JPEG', '.gif': 'GIF', '.webp': 'WEBP'}
     img_format = format_map.get(file_extension.lower(), 'JPEG')
-    img = Image.open(io.BytesIO(image_bytes))
     try:
         resample_filter = Image.Resampling.LANCZOS
     except AttributeError:
         resample_filter = Image.ANTIALIAS
 
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        # Bound peak memory for multi-hundred-Mpx images before any further
+        # processing. thumbnail() is in-place and memory-efficient (uses
+        # libjpeg draft+reduce pipeline for large JPEGs).
+        img.thumbnail((INITIAL_MAX_DIMENSION, INITIAL_MAX_DIMENSION), resample_filter)
+    except Exception as e:
+        logging.warning("Image decode failed: %s: %s", type(e).__name__, e)
+        return None
+
     img_stream = io.BytesIO()
-    while True:
-        img_stream.seek(0)
-        img_stream.truncate(0)
-        img.save(img_stream, format=img_format)
-        if img_stream.getbuffer().nbytes <= max_size_mb * 1024 * 1024:
-            break
-        width, height = img.size
-        img = img.resize(
-            (int(width * (100 - step) / 100), int(height * (100 - step) / 100)),
-            resample_filter
-        )
+    try:
+        while True:
+            img_stream.seek(0)
+            img_stream.truncate(0)
+            img.save(img_stream, format=img_format)
+            if img_stream.getbuffer().nbytes <= max_size_mb * 1024 * 1024:
+                break
+            width, height = img.size
+            new_w = int(width * (100 - step) / 100)
+            new_h = int(height * (100 - step) / 100)
+            if new_w < MIN_DIMENSION or new_h < MIN_DIMENSION:
+                break
+            img.thumbnail((new_w, new_h), resample_filter)
+    except Exception as e:
+        logging.warning("Image resize failed: %s: %s", type(e).__name__, e)
+        return None
     return img_stream
 
 
@@ -282,10 +304,20 @@ async def process_message_with_attachments(message, attachments, cleaned_text, s
 
         if mime_type.startswith('image/'):
             await message.add_reaction('🎨')
-            resized_image_stream = resize_image(file_data, file_extension)
+            # Offload to a thread: LANCZOS/thumbnail on large images can still
+            # take seconds, and blocking the asyncio loop breaks Discord's
+            # gateway heartbeat (seen as ClientConnectionResetError + reconnect).
+            resized_image_stream = await asyncio.to_thread(
+                resize_image, file_data, file_extension
+            )
+            if resized_image_stream is None:
+                await message.channel.send(
+                    f"🎨 画像デコードに失敗したためスキップ: {attachment.filename}"
+                )
+                continue
             encoded_data = base64.b64encode(resized_image_stream.getvalue()).decode("utf-8")
             content.append({
-                "type": "image", 
+                "type": "image",
                 "source": {"type": "base64", "media_type": mime_type, "data": encoded_data}
             })
         elif mime_type == 'application/pdf':


### PR DESCRIPTION
## Summary

[OpenAI_Discordbot PR #16](https://github.com/yasuhiroinoue/OpenAI_Discordbot/pull/16) の本家リポジトリへの移植。`resize_image` 経路にあった 2 つの独立バグを修正。

### 問題 1: DecompressionBombError クラッシュ
Pillow の DoS 保護 (178,956,970 px 上限) が発動して `on_message` 全体が沈黙していた。研究用途の高解像度画像（顕微鏡・天文）で容易に上限超過。

### 問題 2: 同期 `img.resize(LANCZOS)` が asyncio イベントループをブロック
`Loop thread traceback` 警告と Discord gateway heartbeat 切断 (`ClientConnectionResetError` → 自動再接続) が発生していた。

## Changes

1. `Image.MAX_IMAGE_PIXELS = None` で pixel 爆弾チェック撤廃（プライベート bot のトラスト境界上妥当）
2. `resize_image` を `Image.thumbnail()` ベースに書き換え
   - 初手 `thumbnail((4096, 4096))` でピークメモリを抑制
   - decode 失敗 / resize 失敗を per-phase で catch し `None` 返却
   - `MIN_DIMENSION` で無限縮小防止
3. `await asyncio.to_thread(resize_image, ...)` で thread pool に退避
4. None 時は「🎨 画像デコードに失敗したためスキップ」を送信して `continue`（他の添付は処理継続）

LLM 部分（Anthropic SDK）は一切変更なし。

## Test plan
- [x] `python -m py_compile Stream_ClaudeDiscordBot.py` 通過
- [x] bot 正常起動・Gateway 接続確認
- [x] 通常サイズ画像で回帰なし
- [x] 2 億 pixel 級画像でクラッシュせず heartbeat 維持
- [x] 破損画像で skip メッセージが出て他の添付・質問は処理継続

## Ref
- [OpenAI_Discordbot Issue #15](https://github.com/yasuhiroinoue/OpenAI_Discordbot/issues/15)
- [OpenAI_Discordbot PR #16](https://github.com/yasuhiroinoue/OpenAI_Discordbot/pull/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)